### PR TITLE
Use pip -e flag

### DIFF
--- a/figures/Makefile
+++ b/figures/Makefile
@@ -37,6 +37,7 @@ clean:
 
 readme-activities.dot: \
   readme-activities.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py \
   $(top_srcdir)/tests/.venv.done.log
 	source $(top_srcdir)/tests/venv/bin/activate \
 	  && case_prov_dot \
@@ -47,6 +48,7 @@ readme-activities.dot: \
 
 readme-attribution.dot: \
   readme-attribution.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py \
   $(top_srcdir)/tests/.venv.done.log
 	source $(top_srcdir)/tests/venv/bin/activate \
 	  && case_prov_dot \
@@ -58,6 +60,7 @@ readme-attribution.dot: \
 
 readme-provenance-records.dot: \
   readme-provenance-records.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py \
   $(top_srcdir)/tests/.venv.done.log
 	source $(top_srcdir)/tests/venv/bin/activate \
 	  && case_prov_dot \

--- a/tests/CASE-Examples/examples/Makefile
+++ b/tests/CASE-Examples/examples/Makefile
@@ -23,6 +23,8 @@ example_srcdir := $(qc_srcdir)/dependencies/CASE-Examples/examples
 
 tests_srcdir := $(top_srcdir)/tests
 
+sparql_files := $(wildcard $(top_srcdir)/case_prov/queries/construct-*.sparql)
+
 json_files := $(wildcard $(top_srcdir)/dependencies/CASE-Examples-QC/dependencies/CASE-Examples/examples/*.json)
 
 ttl_files := $(foreach json_file,$(json_files),$(subst .json,-prov.ttl,$(shell basename $(json_file))))
@@ -70,7 +72,8 @@ all: \
 	mv _$@ $@
 
 %-all.dot: \
-  %.ttl
+  %.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -79,7 +82,8 @@ all: \
 	mv _$@ $@
 
 %-originals.dot: \
-  %.ttl
+  %.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -90,7 +94,9 @@ all: \
 
 %-prov.ttl: \
   $(example_srcdir)/%.json \
-  $(tests_srcdir)/.venv.done.log
+  $(sparql_files) \
+  $(tests_srcdir)/.venv.done.log \
+  $(top_srcdir)/case_prov/case_prov_rdf.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_rdf \
 	    --allow-empty-results \
@@ -108,7 +114,8 @@ all: \
 	mv _$@ $@
 
 Oresteia-prov.dot: \
-  Oresteia-prov.ttl
+  Oresteia-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -117,7 +124,8 @@ Oresteia-prov.dot: \
 	mv _$@ $@
 
 Oresteia-prov-activities.dot: \
-  Oresteia-prov.ttl
+  Oresteia-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --activity-informing \
@@ -128,7 +136,8 @@ Oresteia-prov-activities.dot: \
 	mv _$@ $@
 
 Oresteia-prov-agents.dot: \
-  Oresteia-prov.ttl
+  Oresteia-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --agent-delegating \
@@ -139,7 +148,8 @@ Oresteia-prov-agents.dot: \
 	mv _$@ $@
 
 Oresteia-prov-entities.dot: \
-  Oresteia-prov.ttl
+  Oresteia-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --entity-deriving \
@@ -150,7 +160,8 @@ Oresteia-prov-entities.dot: \
 	mv _$@ $@
 
 Oresteia-prov-focus-sms-message1-uuid.dot: \
-  Oresteia-prov.ttl
+  Oresteia-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -160,7 +171,8 @@ Oresteia-prov-focus-sms-message1-uuid.dot: \
 	mv _$@ $@
 
 Oresteia-prov-focus-sms-message2-uuid.dot: \
-  Oresteia-prov.ttl
+  Oresteia-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -19,8 +19,6 @@ top_srcdir := $(shell cd .. ; pwd)
 
 qc_srcdir := $(top_srcdir)/dependencies/CASE-Examples-QC
 
-sparql_files := $(wildcard $(top_srcdir)/case_prov/queries/construct-*.sparql)
-
 all: \
   all-CASE-Examples \
   all-casework.github.io
@@ -35,11 +33,7 @@ all: \
 
 .venv.done.log: \
   $(qc_srcdir)/deps/requirements.txt \
-  $(sparql_files) \
   $(top_srcdir)/.git_submodule_init.done.log \
-  $(top_srcdir)/case_prov/__init__.py \
-  $(top_srcdir)/case_prov/case_prov_dot.py \
-  $(top_srcdir)/case_prov/case_prov_rdf.py \
   $(top_srcdir)/dependencies/CASE-Utilities-Python/tests/requirements.txt \
   $(top_srcdir)/setup.cfg \
   $(top_srcdir)/setup.py \
@@ -61,7 +55,9 @@ all: \
 	    --requirement $(top_srcdir)/dependencies/CASE-Utilities-Python/tests/requirements.txt
 	source venv/bin/activate \
 	  && cd $(top_srcdir) \
-	    && python3 setup.py install
+	    && pip install \
+	      --editable \
+	      .
 	source venv/bin/activate \
 	  && pip install \
 	    --requirement $(qc_srcdir)/deps/requirements.txt

--- a/tests/casework.github.io/examples/asgard/Makefile
+++ b/tests/casework.github.io/examples/asgard/Makefile
@@ -23,6 +23,8 @@ example_srcdir := $(qc_srcdir)/dependencies/casework.github.io/examples/asgard
 
 tests_srcdir := $(top_srcdir)/tests
 
+sparql_files := $(wildcard $(top_srcdir)/case_prov/queries/construct-*.sparql)
+
 all: \
   prov-constraints.log \
   asgard-prov.png \
@@ -42,7 +44,8 @@ check: \
   prov-constraints.log
 
 asgard-prov.dot: \
-  asgard-prov.ttl
+  asgard-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -51,7 +54,8 @@ asgard-prov.dot: \
 	mv _$@ $@
 
 asgard-prov-focus-extracted-file-uuid-1.dot: \
-  asgard-prov.ttl
+  asgard-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -61,7 +65,8 @@ asgard-prov-focus-extracted-file-uuid-1.dot: \
 	mv _$@ $@
 
 asgard-prov-originals.dot: \
-  asgard-prov.ttl
+  asgard-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -72,7 +77,9 @@ asgard-prov-originals.dot: \
 
 asgard-prov.ttl: \
   $(example_srcdir)/asgard.json \
-  $(tests_srcdir)/.venv.done.log
+  $(sparql_files) \
+  $(tests_srcdir)/.venv.done.log \
+  $(top_srcdir)/case_prov/case_prov_rdf.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_rdf \
 	    --debug \

--- a/tests/casework.github.io/examples/owl_trafficking/Makefile
+++ b/tests/casework.github.io/examples/owl_trafficking/Makefile
@@ -23,6 +23,8 @@ example_srcdir := $(qc_srcdir)/dependencies/casework.github.io/examples/owl_traf
 
 tests_srcdir := $(top_srcdir)/tests
 
+sparql_files := $(wildcard $(top_srcdir)/case_prov/queries/construct-*.sparql)
+
 all: \
   prov-constraints.log \
   owl_trafficking-prov.png \
@@ -50,7 +52,8 @@ clean:
 	  prov-constraints.log
 
 owl_trafficking-prov.dot: \
-  owl_trafficking-prov.ttl
+  owl_trafficking-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -59,7 +62,8 @@ owl_trafficking-prov.dot: \
 	mv _$@ $@
 
 owl_trafficking-prov-focus-extracted-file-uuid-1.dot: \
-  owl_trafficking-prov.ttl
+  owl_trafficking-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -69,7 +73,8 @@ owl_trafficking-prov-focus-extracted-file-uuid-1.dot: \
 	mv _$@ $@
 
 owl_trafficking-prov-originals.dot: \
-  owl_trafficking-prov.ttl
+  owl_trafficking-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -80,7 +85,9 @@ owl_trafficking-prov-originals.dot: \
 
 owl_trafficking-prov.ttl: \
   $(example_srcdir)/owl_trafficking.json \
-  $(tests_srcdir)/.venv.done.log
+  $(sparql_files) \
+  $(tests_srcdir)/.venv.done.log \
+  $(top_srcdir)/case_prov/case_prov_rdf.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_rdf \
 	    --debug \

--- a/tests/casework.github.io/examples/urgent_evidence/Makefile
+++ b/tests/casework.github.io/examples/urgent_evidence/Makefile
@@ -23,6 +23,8 @@ example_srcdir := $(qc_srcdir)/dependencies/casework.github.io/examples/urgent_e
 
 tests_srcdir := $(top_srcdir)/tests
 
+sparql_files := $(wildcard $(top_srcdir)/case_prov/queries/construct-*.sparql)
+
 all: \
   prov-constraints.log \
   urgent_evidence-prov-activities.svg \
@@ -66,7 +68,9 @@ prov-constraints.log: \
 
 urgent_evidence-prov.ttl: \
   $(example_srcdir)/urgent_evidence.json \
-  $(tests_srcdir)/.venv.done.log
+  $(sparql_files) \
+  $(tests_srcdir)/.venv.done.log \
+  $(top_srcdir)/case_prov/case_prov_rdf.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_rdf \
 	    --debug \
@@ -83,7 +87,8 @@ urgent_evidence-prov.ttl: \
 	mv _$@ $@
 
 urgent_evidence-prov-activities.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --activity-informing \
@@ -94,7 +99,8 @@ urgent_evidence-prov-activities.dot: \
 	mv _$@ $@
 
 urgent_evidence-prov-agents.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --agent-delegating \
@@ -105,7 +111,8 @@ urgent_evidence-prov-agents.dot: \
 	mv _$@ $@
 
 urgent_evidence-prov-activities-focus-extracted-file-uuid-1.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --activity-informing \
@@ -117,7 +124,8 @@ urgent_evidence-prov-activities-focus-extracted-file-uuid-1.dot: \
 	mv _$@ $@
 
 urgent_evidence-prov-all.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --dash-unqualified \
@@ -127,7 +135,8 @@ urgent_evidence-prov-all.dot: \
 	mv _$@ $@
 
 urgent_evidence-prov-all-focus-extracted-file-uuid-1.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --dash-unqualified \
@@ -138,7 +147,8 @@ urgent_evidence-prov-all-focus-extracted-file-uuid-1.dot: \
 	mv _$@ $@
 
 urgent_evidence-prov-all-initial_investigative_actions.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --debug \
@@ -148,7 +158,8 @@ urgent_evidence-prov-all-initial_investigative_actions.dot: \
 	mv _$@ $@
 
 urgent_evidence-prov-entities.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --dash-unqualified \
@@ -159,7 +170,8 @@ urgent_evidence-prov-entities.dot: \
 	mv _$@ $@
 
 urgent_evidence-prov-entities-focus-extracted-file-uuid-1.dot: \
-  urgent_evidence-prov.ttl
+  urgent_evidence-prov.ttl \
+  $(top_srcdir)/case_prov/case_prov_dot.py
 	source $(tests_srcdir)/venv/bin/activate \
 	  && case_prov_dot \
 	    --dash-unqualified \


### PR DESCRIPTION
This speeds local 'make check' round trips while developing, though at
the trade of having to push dependencies into more localized Make
recipes.

References:
* https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-e

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>