### PR TITLE
Use venv instead of virtualenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Python virtualenv for Github runner
-      run: |
-        python -m pip install --upgrade pip
-        pip install virtualenv
     - name: Start from clean state
       run: make clean
     - name: Run tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -39,14 +39,14 @@ all: \
   $(top_srcdir)/setup.py \
   requirements.txt
 	rm -rf venv
-	$(PYTHON3) -m virtualenv \
-	  --python=$(PYTHON3) \
+	$(PYTHON3) -m venv \
 	  venv
 	source venv/bin/activate \
 	  && pip install \
 	    --upgrade \
 	    pip \
-	    setuptools
+	    setuptools \
+	    wheel
 	source venv/bin/activate \
 	  && cd $(top_srcdir)/dependencies/CASE-Utilities-Python \
 	    && pip install .

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -48,16 +48,15 @@ all: \
 	    setuptools \
 	    wheel
 	source venv/bin/activate \
-	  && cd $(top_srcdir)/dependencies/CASE-Utilities-Python \
-	    && pip install .
+	  && pip install \
+	    $(top_srcdir)/dependencies/CASE-Utilities-Python
 	source venv/bin/activate \
 	  && pip install \
 	    --requirement $(top_srcdir)/dependencies/CASE-Utilities-Python/tests/requirements.txt
 	source venv/bin/activate \
-	  && cd $(top_srcdir) \
-	    && pip install \
-	      --editable \
-	      .
+	  && pip install \
+	    --editable \
+	    $(top_srcdir)
 	source venv/bin/activate \
 	  && pip install \
 	    --requirement $(qc_srcdir)/deps/requirements.txt


### PR DESCRIPTION
References:
* [AC-195] Use Python venv instead of virtualenv to build virtual
  environments for CI

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>