### PR TITLE
Default to venv module provided by system python3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
     - name: Start from clean state
       run: make clean
     - name: Run tests
-      run: make check
+      run: make PYTHON3=python check

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,12 @@
 
 SHELL := /bin/bash
 
+PYTHON3 ?= python3
+
 all: \
   .git_submodule_init.done.log
 	$(MAKE) \
+	  PYTHON3=$(PYTHON3) \
 	  --directory tests
 	$(MAKE) \
 	  --directory figures
@@ -29,6 +32,7 @@ all: \
 	git submodule init
 	git submodule update
 	$(MAKE) \
+	  PYTHON3=$(PYTHON3) \
 	  --directory dependencies/CASE-Examples-QC \
 	  .git_submodule_init.done.log
 	touch $@
@@ -36,6 +40,7 @@ all: \
 check: \
   .git_submodule_init.done.log
 	$(MAKE) \
+	  PYTHON3=$(PYTHON3) \
 	  --directory tests \
 	  check
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@
 
 SHELL := /bin/bash
 
-PYTHON3 ?= $(shell which python3.9 2>/dev/null || which python3.8 2>/dev/null || which python3.7 2>/dev/null || which python3.6 2>/dev/null || which python3)
+PYTHON3 ?= which python3
 
 top_srcdir := $(shell cd .. ; pwd)
 


### PR DESCRIPTION
References:
* [AC-195] Use Python venv instead of virtualenv to build virtual
  environments for CI

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>