### PR TITLE
Port wasDerivedFrom and wasInformedBy in CASE usage to PROV

### DIFF
--- a/case_prov/queries/construct-wasDerivedFrom-map.sparql
+++ b/case_prov/queries/construct-wasDerivedFrom-map.sparql
@@ -1,0 +1,17 @@
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+CONSTRUCT {
+  ?x prov:wasDerivedFrom ?y .
+}
+WHERE {
+  ?x case-investigation:wasDerivedFrom ?y .
+}

--- a/case_prov/queries/construct-wasInformedBy-map.sparql
+++ b/case_prov/queries/construct-wasInformedBy-map.sparql
@@ -1,0 +1,17 @@
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+CONSTRUCT {
+  ?x prov:wasInformedBy ?y .
+}
+WHERE {
+  ?x case-investigation:wasInformedBy ?y .
+}


### PR DESCRIPTION
This covers the use case where CASE data includes `wasDerivedFrom`
statements, and the PROV mapping can be used to confirm the
`wasDerivedFrom` statements in CASE are as well supported as the
`wasDerivedFrom` statements constructed from other `case-prov` mapping
queries.

From the current design vocabulary, if a CASE `wasDerivedFrom` statement
is in the graph, but independently asserted without support from the
chain of custody, that `wasDerivedFrom` edge would display as
"unqualified" (a dashed line).

As a reminder, CASE's `wasDerivedFrom` was defined in CASE 0.4.0 to act
like PROV-O's `wasDerivedFrom`, but without entailing domain or range
inferences.

No effects on Make-managed files were observed.

References:
* [ONT-390] (CP-21) Add transitive property to report causal chain of a
  derived object
* https://caseontology.org/releases/0.4.0/

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>