### PR TITLE
Run CI on Python 3.11

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         python-version:
         - '3.7'
-        - '3.10'
+        - '3.11'
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
As with [`case-utils` PR 73](https://github.com/casework/CASE-Utilities-Python/pull/73).