### PR TITLE
Reschedule `pre-commit` refreshing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,22 +1,26 @@
+# Portions of this file contributed by NIST are governed by the following
+# statement:
+#
 # This software was developed at the National Institute of Standards
 # and Technology by employees of the Federal Government in the course
-# of their official duties. Pursuant to title 17 Section 105 of the
-# United States Code this software is not subject to copyright
-# protection and is in the public domain. NIST assumes no
-# responsibility whatsoever for its use by other parties, and makes
-# no guarantees, expressed or implied, about its quality,
-# reliability, or any other characteristic.
+# of their official duties. Pursuant to Title 17 Section 105 of the
+# United States Code, this software is not subject to copyright
+# protection within the United States. NIST assumes no responsibility
+# whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other
+# characteristic.
 #
 # We would appreciate acknowledgement if the software is used.
 
 # This workflow uses Make to review direct dependencies of this
 # repository.
 
-name: Supply Chain
+name: Prerelease
 
 on:
-  schedule:
-    - cron: '15 5 * * 1,2,3,4,5'
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -35,4 +39,4 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Review dependencies
-      run: make check-supply-chain
+      run: make check-supply-chain-pre-commit

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ check: \
 check-supply-chain: \
   check-supply-chain-pre-commit
 
+# This target is scheduled to run as part of prerelease review.
 check-supply-chain-pre-commit: \
   .venv-pre-commit/var/.pre-commit-built.log
 	source .venv-pre-commit/bin/activate \


### PR DESCRIPTION
Because refreshing `pre-commit`'s pinned versions is the only supply chain check for this repository, this PR also removes the nightly supply chain review job.