### PR TITLE
Release 0.12.1

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,13 +35,13 @@ jobs:
         - '3.12'
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Pre-commit Checks
@@ -56,18 +56,18 @@ jobs:
     # Build the binary wheel as well as the source tar
     - name: Build Objects
       run: |
-        pip install -q twine wheel
-        python setup.py sdist bdist_wheel
+        pip install -q twine build
+        python -m build
     # Ensure the objects were packaged correctly and there wasn't an issue with
     # the compilation or packaging process.
     - name: Check Objects
       run: twine check dist/*
 
-    # Upload the packages on all develop and main pipleines for test consumption
+    # Upload the packages on all develop and main pipelines for test consumption
     - name: Upload HTML Docs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
-        name: packages
+        name: packages-${{ matrix.python-version }}
         path: ./dist/
 
     # If this commit is the result of a Git tag, push the wheel and tar packages

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,9 +33,9 @@ jobs:
           - '3.12'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Review dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,15 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.0.0
+    rev: 7.2.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)

--- a/case_prov/case_prov_check.py
+++ b/case_prov/case_prov_check.py
@@ -49,9 +49,11 @@ def main() -> None:
     # could be an error raised before the construction of the argument
     # parser.
     logging.basicConfig(
-        level=logging.DEBUG
-        if ("--debug" in sys.argv or "-d" in sys.argv)
-        else logging.INFO
+        level=(
+            logging.DEBUG
+            if ("--debug" in sys.argv or "-d" in sys.argv)
+            else logging.INFO
+        )
     )
 
     # Add arguments specific to case_prov_check.

--- a/case_prov/case_prov_dot.py
+++ b/case_prov/case_prov_dot.py
@@ -179,7 +179,7 @@ def expand_prov_activities_with_owl_time(
     debug_graph = rdflib.Graph()
 
     def _dump_augments(
-        tmp_triples: typing.Union[rdflib.Graph, case_prov.TmpTriplesType]
+        tmp_triples: typing.Union[rdflib.Graph, case_prov.TmpTriplesType],
     ) -> None:
         """
         Macro: Copy tmp_triples into graph and debug graph.

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ include_package_data = true
 install_requires =
     case_utils >=0.16.0,< 0.17.0
     prov
-    pydot
+    pydot < 4.0.0
+    pyshacl < 0.27.0
 packages = find:
 python_requires = >=3.9
 
@@ -45,6 +46,7 @@ case_prov.shapes = *.ttl
 extend-ignore =
   E203
   E501
+  F824
 
 [isort]
 # https://pycqa.github.io/isort/docs/configuration/black_compatibility.html


### PR DESCRIPTION
Pin pydot to <4.0.0, pySHACL to <0.27.0; bump GitHub Action versions and pre-commit

This is due to type signature updates in major-version revision (pydot)
and type signature activation (pySHACL).  The `develop` branch had had
adapting updates done in PRs 105 and 114, but while waiting for the next
release, this patch will prevent type review issues in current
deployments.

This patch also incorporates effects from PRs 106 through 108, and runs
and applies `pre-commit autoupdate` to mitigate CI matters.

References:
* https://github.com/casework/CASE-Implementation-PROV-O/pull/105
* https://github.com/casework/CASE-Implementation-PROV-O/pull/106
* https://github.com/casework/CASE-Implementation-PROV-O/pull/107
* https://github.com/casework/CASE-Implementation-PROV-O/pull/108
* https://github.com/casework/CASE-Implementation-PROV-O/pull/114