### PR TITLE
Release 0.12.2

### DIFF
--- a/case_prov/__init__.py
+++ b/case_prov/__init__.py
@@ -11,7 +11,7 @@
 #
 # We would appreciate acknowledgement if the software is used.
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 import datetime
 import typing


### PR DESCRIPTION
This hotfix has no changes since the intended 0.12.1.  0.12.1 was accidentally tagged against `develop` instead of `main`, so 0.12.2 is tagged as what was intended as 0.12.1.